### PR TITLE
Update README with deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # kotlin-frontend-plugin  [ ![Download](https://api.bintray.com/packages/kotlin/kotlin-eap/kotlin-frontend/images/download.svg) ](https://bintray.com/kotlin/kotlin-eap/kotlin-frontend/_latestVersion) [![TeamCity (simple build status)](https://img.shields.io/teamcity/http/teamcity.jetbrains.com/s/KotlinTools_KotlinFrontendPlugin_Build.svg)](https://teamcity.jetbrains.com/viewType.html?buildTypeId=KotlinTools_KotlinFrontendPlugin_Build)
 Gradle plugin for Kotlin frontend development
 
+## THIS PLUGIN IS DEPRECATED
+
 The plugin provides an easy way to gather Maven and npm dependencies, pack bundles (via [webpack](https://webpack.github.io/)) and test a frontend application using [Karma](https://karma-runner.github.io/1.0/index.html). By default the plugin generates all required configs for webpack, karma and manages the corresponding daemons.
 
 By using Gradle continuous build, you also can get hot module replacement feature (apply code changes in browser on the fly). See corresponding [section below](#hot-module-replacement).


### PR DESCRIPTION
Hello!

[I've discovered in the Kotlin Slack group](https://kotlinlang.slack.com/archives/C0B8L3U69/p1566290694223000?thread_ts=1566290515.222700&cid=C0B8L3U69) that this plugin is deprecated. Can we please mark this as the case?

If anyone knows the correct place to point people to, that would be very helpful also!

Thanks 